### PR TITLE
Closing connection

### DIFF
--- a/client.go
+++ b/client.go
@@ -92,12 +92,14 @@ func (this *Client) ConnectAndWrite(resp *PushNotificationResponse, payload []by
 	if err != nil {
 		return err
 	}
+	defer conn.Close()
 
 	tlsConn := tls.Client(conn, conf)
 	err = tlsConn.Handshake()
 	if err != nil {
 		return err
 	}
+	defer tlsConn.Close()
 
 	_, err = tlsConn.Write(payload)
 	if err != nil {


### PR DESCRIPTION
Connections were being left open and our server was running out of open files.... All connections open were going to port 2195. So I changed the ConnectAndWrite to defer close the conn and tlsConn and that did it. 

I see you have a select blocking the callback waiting for timeout or failure so I assumed a defer would be ok to close the connections at the end. 

Thoughts?
