### PR TITLE
Fix documentation in complex payload example

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ func main() {
   args := make([]string, 1)
   args[0] = "localized args"
 
-  dict := NewAlertDictionary()
+  dict := apns.NewAlertDictionary()
   dict.Body = "Alice wants Bob to join in the fun!"
   dict.ActionLocKey = "Play a Game!"
   dict.LocKey = "localized key"


### PR DESCRIPTION
Hey,
I spotted that NewAlertDictionary() wasn't fully qualified as apns.NewAlertDictionary() when I was definitely not copy-pasting your example code ;)

Cheers
