### PR TITLE
Use modern notification format.

### DIFF
--- a/push_notification.go
+++ b/push_notification.go
@@ -11,7 +11,7 @@ import (
 	"time"
 )
 
-// Push commands always start with command value 1.
+// Push commands always start with command value 2.
 const PUSH_COMMAND_VALUE = 2
 
 // Your total notification payload cannot exceed 256 bytes.
@@ -72,7 +72,7 @@ type PushNotification struct {
 	Expiry      uint32
 	DeviceToken string
 	payload     map[string]interface{}
-	Priority    int32
+	Priority    uint8
 }
 
 // Constructor. Also initializes the pseudo-random identifier.

--- a/push_notification_test.go
+++ b/push_notification_test.go
@@ -45,8 +45,8 @@ func TestBasicAlert(t *testing.T) {
 
 	bytes, _ := pn.ToBytes()
 	json, _ := pn.PayloadJSON()
-	if len(bytes) != 82 {
-		t.Error("expected 82 bytes; got", len(bytes))
+	if len(bytes) != 98 {
+		t.Error("expected 98 bytes; got", len(bytes))
 	}
 	if len(json) != 69 {
 		t.Error("expected 69 bytes; got", len(json))
@@ -63,8 +63,8 @@ func TestAlertDictionary(t *testing.T) {
 
 	bytes, _ := pn.ToBytes()
 	json, _ := pn.PayloadJSON()
-	if len(bytes) != 207 {
-		t.Error("expected 207 bytes; got", len(bytes))
+	if len(bytes) != 223 {
+		t.Error("expected 223 bytes; got", len(bytes))
 	}
 	if len(json) != 194 {
 		t.Error("expected 194 bytes; got", len(bytes))
@@ -87,8 +87,8 @@ func TestCustomParameters(t *testing.T) {
 
 	bytes, _ := pn.ToBytes()
 	json, _ := pn.PayloadJSON()
-	if len(bytes) != 94 {
-		t.Error("expected 94 bytes; got", len(bytes))
+	if len(bytes) != 110 {
+		t.Error("expected 110 bytes; got", len(bytes))
 	}
 	if len(json) != 81 {
 		t.Error("expected 81 bytes; got", len(json))


### PR DESCRIPTION
New development should use the modern format to connect to APNs, as described in [The Binary Interface and Notification Format.](https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/CommunicatingWIthAPS.html#//apple_ref/doc/uid/TP40008194-CH101-SW4)
