### PR TITLE
Add support for silent notifications for iOS7

### DIFF
--- a/push_notification.go
+++ b/push_notification.go
@@ -43,7 +43,7 @@ type Payload struct {
 	Alert            interface{} `json:"alert,omitempty"`
 	Badge            int         `json:"badge,omitempty"`
 	Sound            string      `json:"sound,omitempty"`
-	ContentAvailable int         `json:"content-available,omnitempty"`
+	ContentAvailable int         `json:"content-available,omitempty"`
 }
 
 // NewPayload creates and returns a Payload structure.


### PR DESCRIPTION
Add the content-available to the payload struct so it can be used for background fetching. Introduced in iOS7.
