### PR TITLE
Set ServerName on crypto/tls Config

### DIFF
--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"net"
+	"strings"
 	"time"
 )
 
@@ -96,8 +97,10 @@ func (client *Client) ConnectAndWrite(resp *PushNotificationResponse, payload []
 		return err
 	}
 
+	gatewayParts := strings.Split(client.Gateway, ":")
 	conf := &tls.Config{
 		Certificates: []tls.Certificate{cert},
+		ServerName: gatewayParts[0],
 	}
 
 	conn, err := net.Dial("tcp", client.Gateway)

--- a/feedback.go
+++ b/feedback.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"net"
+	"strings"
 	"time"
 )
 
@@ -53,8 +54,10 @@ func (client *Client) ListenForFeedback() (err error) {
 		return err
 	}
 
+	gatewayParts := strings.Split(client.Gateway, ":")
 	conf := &tls.Config{
 		Certificates: []tls.Certificate{cert},
+		ServerName: gatewayParts[0],
 	}
 
 	conn, err := net.Dial("tcp", client.Gateway)


### PR DESCRIPTION
This fixes a bug introduced by Go 1.3 (http://golang.org/doc/go1.3#major_library_changes) which was actually a bug in 1.2.

This is not the best way to implement this but was the simplest thing I could do without breaking the API. Ideally, since this package is specific to APNS and APNS gateways are always the same, we should just be able to do something like `client := apns.NewProductionClient(cert, key)` and it will know what the gateway and server name is for production.
