### PR TITLE
ToBytes should error if token is the wrong length.

### DIFF
--- a/push_notification.go
+++ b/push_notification.go
@@ -137,6 +137,9 @@ func (pn *PushNotification) ToBytes() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	if len(token) != 32 {
+		return nil, errors.New("device token is the wrong size; expected 32 bytes but saw " + strconv.Itoa(len(token)))
+	}
 	payload, err := pn.PayloadJSON()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
While working on #14 I've been sending dodgy notifications on purpose.

Doing this, I've noticed that you can provide a device token which is more or less than 32 bytes and this results in the whole notification being malformed.
