### PR TITLE
the key “content-available” is the key that enable a silent notification

### DIFF
--- a/push_notification.go
+++ b/push_notification.go
@@ -43,6 +43,7 @@ type Payload struct {
 	Alert interface{} `json:"alert,omitempty"`
 	Badge int         `json:"badge,omitempty"`
 	Sound string      `json:"sound,omitempty"`
+	ContentAvailable int `json:"content-available,omitempty"`
 }
 
 // NewPayload creates and returns a Payload structure.


### PR DESCRIPTION
It is necessary for a silent notification.

https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html
