### PR TITLE
move test code to separate subpackage

### DIFF
--- a/mock/client_mock.go
+++ b/mock/client_mock.go
@@ -1,6 +1,9 @@
-package apns
+package mock
 
-import "github.com/stretchr/testify/mock"
+import (
+	. "github.com/Coccodrillo/apns"
+	"github.com/stretchr/testify/mock"
+)
 
 type MockClient struct {
 	mock.Mock

--- a/mock/client_mock_test.go
+++ b/mock/client_mock_test.go
@@ -1,9 +1,10 @@
-package apns
+package mock
 
 import (
 	"errors"
 	"testing"
 
+	. "github.com/Coccodrillo/apns"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/mock/mock_feedback_server.go
+++ b/mock/mock_feedback_server.go
@@ -1,4 +1,4 @@
-package apns
+package mock
 
 import (
 	"bytes"


### PR DESCRIPTION
mock_client.go imports testing libraries which previously were compiled
into any program importing this package. This commit moves the mock
client and server to a separate package to remove this dependency.
